### PR TITLE
Omit cookie domain when using localhost

### DIFF
--- a/src/js/helpers/cookies.js
+++ b/src/js/helpers/cookies.js
@@ -37,7 +37,7 @@ module.exports = {
     } else {
       expires = '';
     }
-    if (domain && !excl_subdomains) {
+    if (domain && !excl_subdomains && domain !== 'localhost') {
       basehost = ';domain=.' + domain;
     } else {
       basehost = '';


### PR DESCRIPTION
As mentioned in #16, Cookies aren't set when using localhost.

This PR Omits the cookie domain when using localhost.