### PR TITLE
Fix cookie.js: if domain is IP address

### DIFF
--- a/src/js/helpers/cookies.js
+++ b/src/js/helpers/cookies.js
@@ -38,7 +38,12 @@ module.exports = {
       expires = '';
     }
     if (domain && !excl_subdomains) {
-      basehost = ';domain=.' + domain;
+      // if domain is IP address
+      if (/^(\d{1,3}\.){3}\d{1,3}$/.test(domain)){
+        basehost = ';domain=' + domain;
+      } else {
+        basehost = ';domain=.' + domain;
+      }
     } else {
       basehost = '';
     }


### PR DESCRIPTION
If you develop in localhost (for example: http://192.168.1.148:3000/), need remove dot in domain
Fixes #16 